### PR TITLE
Cleaned up viewmodels. Improved search. Made TypeDocument bindable.

### DIFF
--- a/SaveAll/SaveAll/SaveAll/FrameworkMVVM/ViewModelDeBase.cs
+++ b/SaveAll/SaveAll/SaveAll/FrameworkMVVM/ViewModelDeBase.cs
@@ -1,26 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Text;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.ComponentModel;
+//using System.Runtime.CompilerServices;
+//using System.Text;
+using PropertyChanged;
 
 namespace SaveAll.FrameworkMVVM
 {
-    public class ViewModelDeBase : INotifyPropertyChanged
+    [AddINotifyPropertyChangedInterface]
+    public abstract class ViewModelDeBase //: INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
-        public void NotifyPropertyChanged(string nomPropriete)
+        protected ViewModelDeBase()
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nomPropriete));
+
         }
-        public bool NotifyPropertyChanged<T>(ref T variable, T valeur, [CallerMemberName] string nomPropriete = null)
-        {
-            if (Equals(variable, valeur)) return false;
-            variable = valeur;
-            NotifyPropertyChanged(nomPropriete);
-            return true;
-        }
+
+        //public event PropertyChangedEventHandler PropertyChanged;
+        //public void NotifyPropertyChanged(string nomPropriete)
+        //{
+        //    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nomPropriete));
+        //}
+        //public bool NotifyPropertyChanged<T>(ref T variable, T valeur, [CallerMemberName] string nomPropriete = null)
+        //{
+        //    if (Equals(variable, valeur)) return false;
+        //    variable = valeur;
+        //    NotifyPropertyChanged(nomPropriete);
+        //    return true;
+        //}
     }
-
-
 }

--- a/SaveAll/SaveAll/SaveAll/SaveAll.csproj
+++ b/SaveAll/SaveAll/SaveAll/SaveAll.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="DLToolkit.Forms.Controls.FlowListView" Version="2.0.11" />
     <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.11.982" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.2.6" />
+    <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.1-beta" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Rg.Plugins.Popup-master\src\Rg.Plugins.Popup\Rg.Plugins.Popup.csproj" />

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml
@@ -47,11 +47,13 @@
 
             </StackLayout>
 
-                <SearchBar x:Name="searchBar"
-                           SearchCommand="{Binding SearchCommand}"
-                           Text="{Binding SearchText}"
-                       HorizontalOptions="FillAndExpand"
-                       Placeholder="Rechercher un document..."/>
+                <SearchBar
+                    x:Name="SearchBar"
+                    SearchCommand="{Binding SearchCommand}"
+                    SearchCommandParameter="{Binding SearchText}"
+                    Text="{Binding SearchText}"
+                    HorizontalOptions="FillAndExpand"
+                    Placeholder="Rechercher un document..."/>
 
         </StackLayout>
 
@@ -62,14 +64,16 @@
                          HorizontalOptions="FillAndExpand"
                          Margin="0,5,0,0">
             
-                    <ListView x:Name="listdoc"
-                            ItemsSource="{Binding DocumentList}"
-                            VerticalOptions="FillAndExpand"
-                            SeparatorVisibility="None"
-                            BackgroundColor="#F1F1F1"
-                            RowHeight="100"
-                            SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                            VerticalScrollBarVisibility="Never">
+                    <ListView
+                        x:Name="listdoc"
+                        ItemsSource="{Binding SearchDocumentList}"
+                        VerticalOptions="FillAndExpand"
+                        SeparatorVisibility="None"
+                        BackgroundColor="#F1F1F1"
+                        RowHeight="100"
+                        SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                        VerticalScrollBarVisibility="Never"
+                        ItemSelected="ItemSelected">
 
 
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml
@@ -65,15 +65,14 @@
                          Margin="0,5,0,0">
             
                     <ListView
-                        x:Name="listdoc"
+                        x:Name="ListView"
                         ItemsSource="{Binding SearchDocumentList}"
                         VerticalOptions="FillAndExpand"
                         SeparatorVisibility="None"
                         BackgroundColor="#F1F1F1"
                         RowHeight="100"
                         SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                        VerticalScrollBarVisibility="Never"
-                        ItemSelected="ItemSelected">
+                        VerticalScrollBarVisibility="Never">
 
 
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Rg.Plugins.Popup.Animations;
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Services;
+using SaveAll.Model;
 using SaveAll.ViewModel.ViewModelDocument;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -20,11 +21,18 @@ namespace SaveAll.View
             InitializeComponent();
 
             SearchBar.TextChanged += SearchBar_TextChanged;
+
+            ListView.ItemSelected += ListView_ItemSelected;
         }
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
         {
             ViewModel.SearchCommand.Execute(e.NewTextValue);
+        }
+
+        private void ListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
+        {
+            ViewModel.SelectedItem = e.SelectedItem as Document;
         }
 
         protected override void OnAppearing()

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueDocument.xaml.cs
@@ -13,19 +13,23 @@ namespace SaveAll.View
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class HistoriqueDocument : ContentPage
     {
+        protected ListDocumentViewModel ViewModel => BindingContext as ListDocumentViewModel;
 
         public HistoriqueDocument()
         {
             InitializeComponent();
+
+            SearchBar.TextChanged += SearchBar_TextChanged;
         }
 
-        
+        private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.SearchCommand.Execute(e.NewTextValue);
+        }
+
         protected override void OnAppearing()
         {
-            
-            this.BindingContext = new ListDocumentViewModel(Navigation);
+            BindingContext = new ListDocumentViewModel(Navigation);
         }
-
-       
     }
 }

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml
@@ -65,14 +65,14 @@
                          Margin="0,5,0,0">
             
             <ListView
+               x:Name="ListView"
                 ItemsSource="{Binding SearchEvenementList}"
                 VerticalOptions="FillAndExpand"
                 VerticalScrollBarVisibility="Never"
                 BackgroundColor="#F1F1F1"
                 SeparatorVisibility="None"
                 RowHeight="100"
-                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                ItemSelected="ItemSelected">
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
 
              
 

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml
@@ -47,10 +47,13 @@
 
             </StackLayout>
 
-                <SearchBar SearchCommand="{Binding SearchCommand}"
-                           Text="{Binding SearchText}"
-                       HorizontalOptions="FillAndExpand"
-                       Placeholder="Rechercher un evenement..."/>
+                <SearchBar
+                    x:Name="SearchBar"
+                    SearchCommand="{Binding SearchCommand}"
+                    SearchCommandParameter="{Binding SearchText}"
+                    Text="{Binding SearchText}"
+                    HorizontalOptions="FillAndExpand"
+                    Placeholder="Rechercher un evenement..."/>
 
             </StackLayout>
 
@@ -61,13 +64,15 @@
                          HorizontalOptions="FillAndExpand"
                          Margin="0,5,0,0">
             
-            <ListView ItemsSource="{Binding EvenementList}"
-                            VerticalOptions="FillAndExpand"
-                            VerticalScrollBarVisibility="Never"
-                            BackgroundColor="#F1F1F1"
-                            SeparatorVisibility="None"
-                            RowHeight="100"
-                            SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
+            <ListView
+                ItemsSource="{Binding SearchEvenementList}"
+                VerticalOptions="FillAndExpand"
+                VerticalScrollBarVisibility="Never"
+                BackgroundColor="#F1F1F1"
+                SeparatorVisibility="None"
+                RowHeight="100"
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                ItemSelected="ItemSelected">
 
              
 

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml.cs
@@ -12,17 +12,23 @@ namespace SaveAll.View
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class HistoriqueEvenement : ContentPage
     {
+        protected ListEvementViewModel ViewModel => BindingContext as ListEvementViewModel;
+
         public HistoriqueEvenement()
         {
             InitializeComponent();
+
+            SearchBar.TextChanged += SearchBar_TextChanged;
+        }
+
+        private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.SearchCommand.Execute(e.NewTextValue);
         }
 
         protected override void OnAppearing()
         {
-
-            this.BindingContext = new ListEvementViewModel(Navigation);
+            BindingContext = new ListEvementViewModel(Navigation);
         }
-
-       
     }
 }

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueEvenement.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Rg.Plugins.Popup.Animations;
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Services;
+using SaveAll.Model;
 using SaveAll.ViewModel.ViewModelEvenement;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -19,11 +20,18 @@ namespace SaveAll.View
             InitializeComponent();
 
             SearchBar.TextChanged += SearchBar_TextChanged;
+
+            ListView.ItemSelected += ListView_ItemSelected;
         }
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
         {
             ViewModel.SearchCommand.Execute(e.NewTextValue);
+        }
+
+        private void ListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
+        {
+            ViewModel.SelectedItem = e.SelectedItem as Evenement;
         }
 
         protected override void OnAppearing()

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml
@@ -66,14 +66,14 @@
                          Margin="0,5,0,0">
             
             <ListView
+                x:Name="ListView"
                 ItemsSource="{Binding SearchMembreList}"
                 VerticalOptions="FillAndExpand"
                 SeparatorVisibility="None"
                 RowHeight="100"
                 BackgroundColor="#F1F1F1"
                 VerticalScrollBarVisibility="Never"
-                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                ItemSelected="ItemSelected">
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
 
              
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml
@@ -48,10 +48,13 @@
 
             </StackLayout>
 
-                <SearchBar SearchCommand="{Binding SearchCommand}"
-                           Text="{Binding SearchText}"
-                       HorizontalOptions="FillAndExpand"
-                       Placeholder="Rechercher un membre..."/>
+                <SearchBar
+                    x:Name="SearchBar"
+                    SearchCommand="{Binding SearchCommand}"
+                    SearchCommandParameter="{Binding SearchText}"
+                    Text="{Binding SearchText}"
+                    HorizontalOptions="FillAndExpand"
+                    Placeholder="Rechercher un membre..."/>
 
             </StackLayout>
 
@@ -62,13 +65,15 @@
                          HorizontalOptions="FillAndExpand"
                          Margin="0,5,0,0">
             
-            <ListView ItemsSource="{Binding MembreList}"
-                            VerticalOptions="FillAndExpand"
-                            SeparatorVisibility="None"
-                            RowHeight="100"
-                            BackgroundColor="#F1F1F1"
-                            VerticalScrollBarVisibility="Never"
-                             SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
+            <ListView
+                ItemsSource="{Binding SearchMembreList}"
+                VerticalOptions="FillAndExpand"
+                SeparatorVisibility="None"
+                RowHeight="100"
+                BackgroundColor="#F1F1F1"
+                VerticalScrollBarVisibility="Never"
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                ItemSelected="ItemSelected">
 
              
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Rg.Plugins.Popup.Animations;
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Services;
+using SaveAll.Model;
 using SaveAll.ViewModel.ViewModelMembre;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -12,17 +13,28 @@ namespace SaveAll.View
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class HistoriqueMembre : ContentPage
     {
+        protected ListMembreViewModel ViewModel => BindingContext as ListMembreViewModel;
+
         public HistoriqueMembre()
         {
             InitializeComponent();
+
+            SearchBar.TextChanged += SearchBar_TextChanged;
+        }
+
+        private void ItemSelected(object sender, SelectedItemChangedEventArgs e)
+        {
+            ViewModel.SelectedItem = e.SelectedItem as Membre;
+        }
+
+        private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.SearchCommand.Execute(e.NewTextValue);
         }
 
         protected override void OnAppearing()
         {
-
-            this.BindingContext = new ListMembreViewModel(Navigation);
+            BindingContext = new ListMembreViewModel(Navigation);
         }
-
-
     }
 }

--- a/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriqueMembre.xaml.cs
@@ -20,16 +20,18 @@ namespace SaveAll.View
             InitializeComponent();
 
             SearchBar.TextChanged += SearchBar_TextChanged;
-        }
 
-        private void ItemSelected(object sender, SelectedItemChangedEventArgs e)
-        {
-            ViewModel.SelectedItem = e.SelectedItem as Membre;
+            ListView.ItemSelected += ListView_ItemSelected1;
         }
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
         {
             ViewModel.SearchCommand.Execute(e.NewTextValue);
+        }
+
+        private void ListView_ItemSelected1(object sender, SelectedItemChangedEventArgs e)
+        {
+            ViewModel.SelectedItem = e.SelectedItem as Membre;
         }
 
         protected override void OnAppearing()

--- a/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml
@@ -49,10 +49,13 @@
 
             </StackLayout>
 
-                <SearchBar SearchCommand="{Binding SearchCommand}"
-                           Text="{Binding SearchText}"
-                       HorizontalOptions="FillAndExpand"
-                       Placeholder="Rechercher un bien..."/>
+                <SearchBar
+                    x:Name="SearchBar"
+                    SearchCommand="{Binding SearchCommand}"
+                    SearchCommandParameter="{Binding SearchText}"
+                    Text="{Binding SearchText}"
+                    HorizontalOptions="FillAndExpand"
+                    Placeholder="Rechercher un bien..."/>
 
             </StackLayout>
 
@@ -63,13 +66,15 @@
                          HorizontalOptions="FillAndExpand"
                          Margin="0,5,0,0">
             
-            <ListView ItemsSource="{Binding PatrimoineList}"
-                            VerticalOptions="FillAndExpand"
-                            SeparatorVisibility="None"
-                            RowHeight="100"
-                            BackgroundColor="#F1F1F1"
-                            VerticalScrollBarVisibility="Never"
-                             SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
+            <ListView
+                ItemsSource="{Binding SearchPatrimoineList}"
+                VerticalOptions="FillAndExpand"
+                SeparatorVisibility="None"
+                RowHeight="100"
+                BackgroundColor="#F1F1F1"
+                VerticalScrollBarVisibility="Never"
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                ItemSelected="ItemSelected">
 
              
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml
@@ -67,14 +67,14 @@
                          Margin="0,5,0,0">
             
             <ListView
+                x:Name="ListView"
                 ItemsSource="{Binding SearchPatrimoineList}"
                 VerticalOptions="FillAndExpand"
                 SeparatorVisibility="None"
                 RowHeight="100"
                 BackgroundColor="#F1F1F1"
                 VerticalScrollBarVisibility="Never"
-                SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                ItemSelected="ItemSelected">
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
 
              
             <ListView.ItemTemplate>

--- a/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml.cs
@@ -7,15 +7,24 @@ namespace SaveAll.View
 {
     public partial class HistoriquePatrimoine : ContentPage
     {
+        protected ListPatrimoineViewModel ViewModel => BindingContext as ListPatrimoineViewModel;
+
         public HistoriquePatrimoine()
         {
             InitializeComponent();
+
+            SearchBar.TextChanged += SearchBar_TextChanged;
         }
-         
+
+        private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.SearchCommand.Execute(e.NewTextValue);
+        }
+
         protected override void OnAppearing()
         {
 
-            this.BindingContext = new ListPatrimoineViewModel(Navigation);
+            BindingContext = new ListPatrimoineViewModel(Navigation);
         }
 
     }

--- a/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/HistoriquePatrimoine.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SaveAll.Model;
 using SaveAll.ViewModel.ViewModelPatrimoine;
 using Xamarin.Forms;
 
@@ -14,6 +15,8 @@ namespace SaveAll.View
             InitializeComponent();
 
             SearchBar.TextChanged += SearchBar_TextChanged;
+
+            ListView.ItemSelected += ListView_ItemSelected;
         }
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
@@ -21,9 +24,13 @@ namespace SaveAll.View
             ViewModel.SearchCommand.Execute(e.NewTextValue);
         }
 
+        private void ListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
+        {
+            ViewModel.SelectedItem = e.SelectedItem as Patrimoine;
+        }
+
         protected override void OnAppearing()
         {
-
             BindingContext = new ListPatrimoineViewModel(Navigation);
         }
 

--- a/SaveAll/SaveAll/SaveAll/View/IdentityCardpage.xaml
+++ b/SaveAll/SaveAll/SaveAll/View/IdentityCardpage.xaml
@@ -76,6 +76,7 @@
 
 
                         <custom:EntryRendererIdentiteHaut
+                                        x:Name="LoginEntry"
                                        Placeholder="Nom d'utilisateur"
                                        HorizontalOptions="FillAndExpand"
                                        Keyboard="Text"

--- a/SaveAll/SaveAll/SaveAll/View/IdentityCardpage.xaml.cs
+++ b/SaveAll/SaveAll/SaveAll/View/IdentityCardpage.xaml.cs
@@ -18,8 +18,14 @@ namespace SaveAll.View
             InitializeComponent();
             BindingContext = new LoginUtilisateurViewModel(Navigation);
             defaultActivityIndicator.IsVisible = false;
+
+            LoginEntry.TextChanged += LoginEntry_TextChanged;
         }
 
+        private void LoginEntry_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            
+        }
 
         void OnButtonClicked(object sender, EventArgs e)
         {

--- a/SaveAll/SaveAll/SaveAll/ViewModel/FilActualitePageView/BaseFilActualiteViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/FilActualitePageView/BaseFilActualiteViewModel.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Rg.Plugins.Popup.Animations;
-using Rg.Plugins.Popup.Enums;
-using Rg.Plugins.Popup.Services;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Model;
 using SaveAll.View;
@@ -22,71 +19,49 @@ namespace SaveAll.ViewModel.FilActualitePageView
         public TypeEvenement _typeEvenement;
         public INavigation _navigation;
 
+        public string DescriptionEvenement { get; set; }
+        public DateTime? ProchainEvenemt { get; set; }
+        public string nomEvenement { get; set; }
+        public string Nom { get; set; }
+        public string Prenom { get; set; }
+        public string Adresse { get; set; }
+        public string NomTypeMembre { get; set; }
+        public string DescriptionDocument { get; set; }
+        public string nomDocument { get; set; }
+        public string NomTypeDocument { get; set; }
+        public string NomDuBien { get; set; }
+        public string NomTypePatrimoine { get; set; }
+        public string DescriptionPatrimoine { get; set; }
+        public List<Membre> MembreList { get; set; }
+        public List<Document> DocumentList { get; set; }
+        public List<Evenement> EvenementList { get; set; }
+        public List<Patrimoine> PatrimoineList { get; set; }
+        public List<TypeDocument> TypeDocumentList { get; set; }
+        public List<TypeMembre> TypeMembreList { get; set; }
+        public List<TypePatrimoine> TypePatrimoineList { get; set; }
+        public Membre SelectedMembre { get; set; }
+        public Document SelectedDocument { get; set; }
+        public Evenement SelectedEvenement { get; set; }
+        public Patrimoine SelectedPatrimoine { get; set; }
 
-
-        // information de la classe membre
-
-        public string Nom
+        void OnSelectedMembreChanged()
         {
-            get => _membre.Nom;
-            set
-            {
-                _membre.Nom = value;
-                NotifyPropertyChanged("Nom");
-            }
+            ShowMembreDetails(SelectedMembre.Id);
         }
 
-
-        public string Prenom
+        void OnSelectedDocumentChanged()
         {
-            get => _membre.Prenom;
-            set
-            {
-                _membre.Prenom = value;
-                NotifyPropertyChanged("Prenom");
-            }
+            ShowDocumentsDetails(SelectedDocument.Id);
         }
 
-
-        public string Adresse
+        void OnSelectedEvenementChanged()
         {
-            get => _membre.Adresse;
-            set
-            {
-                _membre.Adresse = value;
-                NotifyPropertyChanged("Adresse");
-            }
+            ShowEvenementDetails(SelectedEvenement.id);
         }
 
-
-        public string NomTypeMembre
+        void OnSelectedPatrimoineChanged()
         {
-            get => _typeMembre.NomTypeMembre;
-            set
-            {
-                _typeMembre.NomTypeMembre = value;
-                NotifyPropertyChanged("NomTypeMembre");
-            }
-        }
-
-
-
-        Membre selectedMembre;
-        public Membre SelectedMembre
-        {
-            get
-            {
-                return selectedMembre;
-            }
-            set
-            {
-                if (selectedMembre != value)
-                {
-                    selectedMembre = value;
-                    NotifyPropertyChanged("SelectedMembre");
-                    ShowMembreDetails(value.Id);
-                }
-            }
+            ShowPatrimoineDetails(SelectedPatrimoine.Id);
         }
 
         [Obsolete]
@@ -96,65 +71,6 @@ namespace SaveAll.ViewModel.FilActualitePageView
             _navigation.PushAsync(pr);
         }
 
-
-        // informations de la classe document
-
-        public string DescriptionDocument
-        {
-            get => _document.DescriptionDocument;
-            set
-            {
-                _document.DescriptionDocument = value;
-                NotifyPropertyChanged("DescriptionDocument");
-            }
-        }
-
-        public string nomDocument
-        {
-            get => _document.nomDocument;
-
-            set
-            {
-                _document.nomDocument = value;
-                NotifyPropertyChanged("nomDocument");
-            }
-        }
-
-        public string NomTypeDocument
-        {
-            get => _typeDocument.NomTypeDocument;
-
-            set
-            {
-                _typeDocument.NomTypeDocument = value;
-                NotifyPropertyChanged("NomTypeDocument");
-            }
-        }
-
-
-
-
-        Document selectedDocument;
-        public Document SelectedDocument
-        {
-            get
-            {
-                return selectedDocument;
-            }
-            set
-            {
-                if (selectedDocument != value)
-                {
-                    selectedDocument = value;
-                    NotifyPropertyChanged("SelectedDocument");
-                    ShowDocumentsDetails(value.Id);
-                }
-            }
-        }
-
-
-
-
         [Obsolete]
         private void ShowDocumentsDetails(int selectedDocumentID)
         {
@@ -162,222 +78,18 @@ namespace SaveAll.ViewModel.FilActualitePageView
             _navigation.PushAsync(pr);
         }
 
-
-        // information de la classe evenement
-
-        public string DescriptionEvenement
-        {
-            get => _evenement.DescriptionEvenement;
-            set
-            {
-                _evenement.DescriptionEvenement = value;
-                NotifyPropertyChanged("DescriptionEvenement");
-            }
-        }
-
-
-        public DateTime? ProchainEvenemt
-        {
-            get => _evenement.ProchainEvenemt;
-            set
-            {
-                _evenement.ProchainEvenemt = value;
-                NotifyPropertyChanged("ProchainEvenemt");
-            }
-        }
-
-        public string nomEvenement
-        {
-            get => _evenement.nomEvenement;
-
-            set
-            {
-                _evenement.nomEvenement = value;
-                NotifyPropertyChanged("nomEvenement");
-            }
-        }
-
-      
-
-        Evenement selectedEvenement;
-        public Evenement SelectedEvenement
-        {
-            get
-            {
-                return selectedEvenement;
-            }
-            set
-            {
-                if (selectedEvenement != value)
-                {
-                    selectedEvenement = value;
-                    NotifyPropertyChanged("SelectedEvenement");
-                    ShowEvenementDetails(value.id);
-                }
-            }
-        }
-
         [Obsolete]
         private void ShowEvenementDetails(int selectedEvenementID)
         {
             var pr = new DetailsEvenementPageView(selectedEvenementID);
-            
             _navigation.PushAsync(pr);
-        }
-
-
-        //Informartions de la classe patrimoine
-
-        public string NomDuBien
-        {
-            get => _patrimoine.NomDuBien;
-
-            set
-            {
-                _patrimoine.NomDuBien = value;
-                NotifyPropertyChanged("NomDuBien");
-            }
-        }
-
-
-        public string NomTypePatrimoine
-        {
-            get => _typePatrimoine.NomTypePatrimoine;
-
-            set
-            {
-                _typePatrimoine.NomTypePatrimoine = value;
-                NotifyPropertyChanged("NomTypePatrimoine");
-            }
-        }
-
-
-        public string DescriptionPatrimoine
-        {
-            get => _patrimoine.DescriptionPatrimoine;
-
-            set
-            {
-                _patrimoine.DescriptionPatrimoine = value;
-                NotifyPropertyChanged("DescriptionPatrimoine");
-            }
-        }
-
-        Patrimoine selectedPatrimoine;
-        public Patrimoine SelectedPatrimoine
-        {
-            get
-            {
-                return selectedPatrimoine;
-            }
-            set
-            {
-                if (selectedPatrimoine != value)
-                {
-                    selectedPatrimoine = value;
-                    NotifyPropertyChanged("SelectedPatrimoine");
-                    ShowPatrimoineDetails(value.Id);
-                }
-            }
         }
 
         [Obsolete]
         private void ShowPatrimoineDetails(int selectedPatrimoineID)
         {
             var pr = new DetailsPatrimoinePageView(selectedPatrimoineID);
-            
             _navigation.PushAsync(pr);
         }
-
-
-        // listes des 04 classes 
-
-
-        List<Membre> _membreList;
-        public List<Membre> MembreList
-        {
-            get => _membreList;
-            set
-            {
-                _membreList = value;
-                NotifyPropertyChanged("MembreList");
-            }
-        }
-
-
-
-        List<Document> _documentList;
-        public List<Document> DocumentList
-        {
-            get => _documentList;
-            set
-            {
-                _documentList = value;
-                NotifyPropertyChanged("DocumentList");
-            }
-        }
-
-
-        List<Evenement> _evenementList;
-        public List<Evenement> EvenementList
-        {
-            get => _evenementList;
-            set
-            {
-                _evenementList = value;
-                NotifyPropertyChanged("EvenementList");
-            }
-        }
-
-        List<Patrimoine> _patrimoineList;
-        public List<Patrimoine> PatrimoineList
-        {
-            get => _patrimoineList;
-            set
-            {
-                _patrimoineList = value;
-                NotifyPropertyChanged("PatrimoineList");
-            }
-        }
-
-
-        // listes des types des 04 classes
-
-        List<TypeDocument> _typedocumentList;
-        public List<TypeDocument> TypeDocumentList
-        {
-            get => _typedocumentList;
-            set
-            {
-                _typedocumentList = value;
-                NotifyPropertyChanged("TypeDocumentList");
-            }
-        }
-
-
-        List<TypeMembre> _typemembreList;
-        public List<TypeMembre> TypeMembreList
-        {
-            get => _typemembreList;
-            set
-            {
-                _typemembreList = value;
-                NotifyPropertyChanged("TypeMembreList");
-            }
-        }
-
-
-        List<TypePatrimoine> _typepatrimoineList;
-        public List<TypePatrimoine> TypePatrimoineList
-        {
-            get => _typepatrimoineList;
-            set
-            {
-                _typepatrimoineList = value;
-                NotifyPropertyChanged("TypePatrimoineList");
-            }
-        }
-
-
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/FilActualitePageView/ListFilActualiteViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/FilActualitePageView/ListFilActualiteViewModel.cs
@@ -236,8 +236,9 @@ namespace SaveAll.ViewModel.FilActualitePageView
 
         async Task FetchDocumentsAsync()
         {
-            
-            DocumentList = await App.MembreActuel.SesDocuments();
+            DocumentList.Clear();
+            DocumentList.AddRange(await App.MembreActuel.SesDocuments());
+
             TypeDocumentList = await new DatabaseHelper().TousLesTypesDocumentsAsync();
             // fonctionnalite pour recuperer tous les enregistrements
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
@@ -14,7 +14,7 @@ namespace SaveAll.ViewModel.ViewModelDocument
     public class BaseDocumentViewModel : ViewModelDeBase
     {
         public Document _document;
-        public TypeDocument _typeDocument;
+        public TypeDocument TypeDocument { get; set; }
         public BaseParametresViewModel baseParametresViewModel;
         public ILocalNotificationService _localNotificationService;
         public INavigation _navigation;
@@ -45,6 +45,13 @@ namespace SaveAll.ViewModel.ViewModelDocument
             SearchCommand = new MvvmHelpers.Commands.Command<string>(searchText => DoSearchCommand(searchText));
 
             DocumentList.CollectionChanged += DocumentList_CollectionChanged;
+        }
+
+        // Because we're using PropertyChanged.Fody, we can use the "void On[MyProperty]Changed()" convention in order to catch PropertyChanged events and act upon them.
+        void OnTypeDocumentChanged()
+        {
+            NomTypeDocument = TypeDocument.NomTypeDocument;
+            System.Diagnostics.Debug.WriteLine($"*** Called {nameof(OnTypeDocumentChanged)}(). {nameof(TypeDocument)}.{nameof(TypeDocument.NomTypeDocument)}: {TypeDocument.NomTypeDocument}");
         }
 
         private void DocumentList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
@@ -1,15 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Input;
 using FluentValidation;
-using Plugin.FilePicker;
-using Plugin.FilePicker.Abstractions;
+using MvvmHelpers;
 using SaveAll.FrameworkMVVM;
-using SaveAll.Helpers;
 using SaveAll.Interfaces;
 using SaveAll.Model;
 using SaveAll.ViewModel.ViewModelParametres;
@@ -23,242 +17,54 @@ namespace SaveAll.ViewModel.ViewModelDocument
         public TypeDocument _typeDocument;
         public BaseParametresViewModel baseParametresViewModel;
         public ILocalNotificationService _localNotificationService;
-
         public INavigation _navigation;
         public IValidator _documentValidator;
 
+        public string nomDocument { get; set; }
+        public List<TypeDocument> TypedocumentList { get; set; }
+        public string NomTypeDocument { get; set; }
+        public string Code { get; set; }
+        public bool? Periodicite { get; set; }
+        public string DescriptionDocument { get; set; }
+        public DateTime DateEts { get; set; }
+        public DateTime DateExp { get; set; }
+        public TimeSpan HeureExp { get; set; }
+        public string Organisme { get; set; }
+        public byte[] Photo { get; set; }
+        public byte[] Fichier { get; set; }
+        public string NomduFichier { get; set; }
+        public string AccesFichier { get; set; }
+        public string SearchText { get; set; }
+        public ObservableRangeCollection<Document> DocumentList { get; set; } = new ObservableRangeCollection<Document>();
+        public ObservableRangeCollection<Document> SearchDocumentList { get; set; } = new ObservableRangeCollection<Document>();
 
-  
+        public MvvmHelpers.Commands.Command<string> SearchCommand { get; set; }
 
-        public string nomDocument
+        public BaseDocumentViewModel()
         {
-            get => _document.nomDocument;
+            SearchCommand = new MvvmHelpers.Commands.Command<string>(searchText => DoSearchCommand(searchText));
 
-            set
+            DocumentList.CollectionChanged += DocumentList_CollectionChanged;
+        }
+
+        private void DocumentList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            SearchDocumentList.Clear();
+            SearchDocumentList.AddRange(DocumentList);
+        }
+
+        void DoSearchCommand(string searchText)
+        {
+            if (string.IsNullOrEmpty(searchText))
             {
-                _document.nomDocument = value;
-                NotifyPropertyChanged("nomDocument");
+                SearchDocumentList.Clear();
+                SearchDocumentList.AddRange(DocumentList);
+            }
+            else
+            {
+                SearchDocumentList.Clear();
+                SearchDocumentList.AddRange(DocumentList.Where(x => x.nomDocument.Contains(searchText)));
             }
         }
-
-
-        /// <summary>
-        /// INFOS TYPE DOCUMENT
-        /// </summary>
-        public List<TypeDocument> TypedocumentList
-        {
-            get;
-            set;
-        }
-
-
-
-        public string NomTypeDocument
-        {
-            get => _typeDocument.NomTypeDocument;
-
-            set
-            {
-                _typeDocument.NomTypeDocument = value;
-                NotifyPropertyChanged("NomTypeDocument");
-            }
-        }
-
-        /// <summary>
-        /// ///
-        /// </summary>
-
-
-
-
-        public string Code
-        {
-            get => _document.Code;
-            set
-            {
-                _document.Code = value;
-                NotifyPropertyChanged("Code");
-            }
-        }
-
-        
-        public bool? Periodicite
-        {
-            get => _document.Periodicite;
-            set
-            {
-                _document.Periodicite = value;
-                NotifyPropertyChanged("Periodicite");
-            }
-        }
-
-
-        public string DescriptionDocument
-        {
-            get => _document.DescriptionDocument;
-            set
-            {
-                _document.DescriptionDocument = value;
-                NotifyPropertyChanged("DescriptionDocument");
-            }
-        }
-
-        public DateTime DateEts
-        {
-            get => _document.DateEts;
-            set
-            {
-                _document.DateEts = value;
-                NotifyPropertyChanged("DateEts");
-            }
-        }
-
-        public DateTime DateExp
-        {
-            get => _document.DateExp;
-            set
-            {
-                _document.DateExp = value;
-                NotifyPropertyChanged("DateExp");
-            }
-        }
-
-
-        public TimeSpan HeureExp
-        {
-            get => _document.HeureExp;
-            set
-            {
-                _document.HeureExp = value;
-                NotifyPropertyChanged("HeureExp");
-            }
-        }
-
-        public string Organisme
-        {
-            get => _document.Organisme;
-            set
-            {
-                _document.Organisme = value;
-                NotifyPropertyChanged("Organisme");
-            }
-        }
-
-
-
-        public byte[] Photo
-        {
-            get => _document.Photo;
-            set
-            {
-                _document.Photo = value;
-                NotifyPropertyChanged("Photo");
-            }
-        }
-
-
-
-        public byte[] Fichier
-        {
-            get => _document.Fichier;
-            set
-            {
-                _document.Fichier = value;
-                NotifyPropertyChanged("Fichier");
-            }
-        }
-
-        public string NomduFichier
-        {
-            get => _document.NomduFichier;
-            set
-            {
-                _document.NomduFichier = value;
-                NotifyPropertyChanged("NomduFichier");
-            }
-        }
-
-        public string AccesFichier
-        {
-            get => _document.AccesFichier;
-            set
-            {
-                _document.AccesFichier = value;
-                NotifyPropertyChanged("AccesFichier");
-            }
-        }
-
-
-
-        List<Document> _documentList;
-        public List<Document> DocumentList
-        {
-            get
-            {
-                List<Document> theCollection = new List<Document>();
-
-                if (_documentList != null)
-                {
-                    List<Document> entities = (from e in _documentList
-                                               where e.nomDocument.Contains(_searchText)
-                                               select e).ToList<Document>();
-                    if (entities != null && entities.Any())
-                    {
-                        theCollection = new List<Document>(entities);
-                    }
-                    else
-                    {
-                        
-                    }
-                }
-
-                return theCollection;
-            }
-            set
-            {
-                _documentList = value;
-                NotifyPropertyChanged("DocumentList");
-            }
-        }
-
-
-
-        private string _searchText = string.Empty;
-        public string SearchText
-        {
-            get { return _searchText; }
-            set
-            {
-                if (_searchText != value) { _searchText = value ?? string.Empty; NotifyPropertyChanged("SearchText"); }
-
-                if (SearchCommand.CanExecute(null))
-                {
-                    SearchCommand.Execute(null);
-                }
-            }
-        }
-
-
-
-        private Command _searchCommand;
-        public ICommand SearchCommand
-        {
-            get
-            {
-                _searchCommand = _searchCommand ?? new Command(DoSearchCommand, CanExecuteSearchCommand);
-                return _searchCommand;
-            }
-        }
-        private void DoSearchCommand()
-        {
-            // Refresh the list, which will automatically apply the search text
-            NotifyPropertyChanged("DocumentList");
-        }
-        private bool CanExecuteSearchCommand()
-        {
-            return true;
-        }
-
-
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/BaseDocumentViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using MvvmHelpers;
+using PropertyChanged;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Interfaces;
 using SaveAll.Model;
@@ -22,7 +23,12 @@ namespace SaveAll.ViewModel.ViewModelDocument
 
         public string nomDocument { get; set; }
         public List<TypeDocument> TypedocumentList { get; set; }
-        public string NomTypeDocument { get; set; }
+
+        // You can use property attributes from PropertyChanged.Fody to chain together properties.
+        // In this case, I'm telling NomTypeDocument that it should fire a Propertychanged event each time that TypeDocument changes, and that it should get its value from TypeDocument.NomTypeDocument.
+        [DependsOn(nameof(TypeDocument))] 
+        public string NomTypeDocument => TypeDocument.NomTypeDocument;
+
         public string Code { get; set; }
         public bool? Periodicite { get; set; }
         public string DescriptionDocument { get; set; }
@@ -48,10 +54,21 @@ namespace SaveAll.ViewModel.ViewModelDocument
         }
 
         // Because we're using PropertyChanged.Fody, we can use the "void On[MyProperty]Changed()" convention in order to catch PropertyChanged events and act upon them.
-        void OnTypeDocumentChanged()
+        // I commented this out in order to demonstrate the [DependsOn()] attribute above.
+        // Either of the two strategies work well. Using attributes is syntactically compact and simple, whereas On[MyProperty]Changed is robust and extendable.
+        // Excercise caution when using the two different strategies in tandem.
+
+        //void OnTypeDocumentChanged()
+        //{
+        //    NomTypeDocument = TypeDocument.NomTypeDocument;
+        //    System.Diagnostics.Debug.WriteLine($"*** Called {nameof(OnTypeDocumentChanged)}(). {nameof(TypeDocument)}.{nameof(TypeDocument.NomTypeDocument)}: {TypeDocument.NomTypeDocument}");
+        //}
+
+        // This method will not get called if [DependsOn(nameof(TypeDocument))] is applied to the NomTypeDocument property.
+        // But if you removed [DependsOn(nameof(TypeDocument))] from NomTypeDocument property and made it a get/set, this method would fire.
+        void OnNomTypeDocumentChanged()
         {
-            NomTypeDocument = TypeDocument.NomTypeDocument;
-            System.Diagnostics.Debug.WriteLine($"*** Called {nameof(OnTypeDocumentChanged)}(). {nameof(TypeDocument)}.{nameof(TypeDocument.NomTypeDocument)}: {TypeDocument.NomTypeDocument}");
+            System.Diagnostics.Debug.WriteLine($"{nameof(OnNomTypeDocumentChanged)}(): NomTypeDocument = {NomTypeDocument}");
         }
 
         private void DocumentList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/DetailsDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/DetailsDocumentViewModel.cs
@@ -29,7 +29,8 @@ namespace SaveAll.ViewModel.ViewModelDocument
             _navigation = navigation;
             _document = new Document();
             _document.Id = selectedDocumentID;
-            _typeDocument = new TypeDocument
+
+            TypeDocument = new TypeDocument
             {
                 IdTypeDocument = selectedDocumentID
             };
@@ -109,7 +110,7 @@ namespace SaveAll.ViewModel.ViewModelDocument
 
             _document.Fichier = StreamToByteArray(stream);
             _document = await new DatabaseHelper().DocumentByIdAsync(_document.Id);
-            _typeDocument = await new DatabaseHelper().TypeDocumentByIdAsync(_typeDocument.IdTypeDocument);
+            TypeDocument = await new DatabaseHelper().TypeDocumentByIdAsync(_document.IdTypeDoc.Value);
         }
 
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/EnregistrementDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/EnregistrementDocumentViewModel.cs
@@ -29,7 +29,7 @@ namespace SaveAll.ViewModel.ViewModelDocument
         {
             _navigation = navigation;
             _document = new Document();
-            _typeDocument = new TypeDocument();
+            TypeDocument = new TypeDocument();
             _documentValidator = new DocumentValidator();
             baseParametresViewModel = new BaseParametresViewModel();
             _localNotificationService = DependencyService.Get<ILocalNotificationService>();

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/ListDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/ListDocumentViewModel.cs
@@ -100,6 +100,7 @@ namespace SaveAll.ViewModel.ViewModelDocument
 
         public Document SelectedItem { get; set; }
 
+        // This method gets called because of PropertyChanged.Fody. Follows the convention: void On[MyProperty]Changed()
         void OnSelectedItemChanged()
         {
             ShowDocumentsDetails(SelectedItem.Id);

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/ListDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/ListDocumentViewModel.cs
@@ -17,14 +17,13 @@ namespace SaveAll.ViewModel.ViewModelDocument
         public ICommand AddCommand { get; private set; }
         public ICommand DeleteAllCommand { get; private set; }
         public ICommand AjouterCommand { get; private set; }
-        public ICommand SearchCommand { get; private set; }
 
 
         public ListDocumentViewModel(INavigation navigation)
         {
             _navigation = navigation;
 
-          
+
             DeleteAllCommand = new Command(async () => await DeleteAllDocuments());
             AjouterCommand = new Command(async () => await AddNewDocumentSecond());
 
@@ -36,10 +35,10 @@ namespace SaveAll.ViewModel.ViewModelDocument
 
             FetchDocumentsAsync();
 
-            
+
         }
 
-       
+
 
         /// <summary>
         /// Afiicher la liste des documents 
@@ -48,10 +47,10 @@ namespace SaveAll.ViewModel.ViewModelDocument
 
         async Task FetchDocumentsAsync()
         {
+            DocumentList.Clear();
+            DocumentList.AddRange(await App.MembreActuel.SesDocuments());            // fonctionnalite pour recuperer tous les enregistrements
 
-            DocumentList = await App.MembreActuel.SesDocuments();            // fonctionnalite pour recuperer tous les enregistrements
 
-            
         }
 
 
@@ -64,9 +63,9 @@ namespace SaveAll.ViewModel.ViewModelDocument
         async Task AddNewDocumentSecond()
         {
             var pr = new NouveauDocumentPageView();
-          
+
             await PopupNavigation.PushAsync(pr);
-            
+
         }
 
 
@@ -91,27 +90,19 @@ namespace SaveAll.ViewModel.ViewModelDocument
         /// <param name="selectedDocumentID"></param>
         /// <returns></returns>
 
-      [Obsolete]
-     async Task ShowDocumentsDetails(int selectedDocumentID)
-     {
-         var pr = new DetailsDocumentPageView(selectedDocumentID);
-        
-         await _navigation.PushAsync(pr);
-     }
-    
-     Document _selectedItem;
-     public Document SelectedItem
-     {
-         get => _selectedItem;
-         set
-         {
-             if (value != null)
-             {
-                 _selectedItem = value;
-                 NotifyPropertyChanged("SelectedItem");
-                 ShowDocumentsDetails(value.Id);
-             }
-         }
-     }
+        [Obsolete]
+        async Task ShowDocumentsDetails(int selectedDocumentID)
+        {
+            var pr = new DetailsDocumentPageView(selectedDocumentID);
+
+            await _navigation.PushAsync(pr);
+        }
+
+        public Document SelectedItem { get; set; }
+
+        void OnSelectedItemChanged()
+        {
+            ShowDocumentsDetails(SelectedItem.Id);
+        }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/MiseAjourDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelDocument/MiseAjourDocumentViewModel.cs
@@ -30,7 +30,8 @@ namespace SaveAll.ViewModel.ViewModelDocument
             _documentValidator = new DocumentValidator();
             _document = new Document();
             _document.Id = selectedDocumentID;
-            _typeDocument = new TypeDocument
+
+            TypeDocument = new TypeDocument
             {
                 IdTypeDocument = selectedDocumentID
             };
@@ -156,7 +157,7 @@ namespace SaveAll.ViewModel.ViewModelDocument
         async Task FetchDocumentDetailsAsync()
         {
             _document = await new DatabaseHelper().DocumentByIdAsync(_document.Id);
-            _typeDocument = await new DatabaseHelper().TypeDocumentByIdAsync(_typeDocument.IdTypeDocument);
+            TypeDocument = await new DatabaseHelper().TypeDocumentByIdAsync(_document.IdTypeDoc.Value);
 
         }
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/BaseEvenementViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/BaseEvenementViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
 using FluentValidation;
+using MvvmHelpers;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Model;
 using Syncfusion.SfCalendar.XForms;
@@ -12,193 +13,51 @@ namespace SaveAll.ViewModel.ViewModelEvenement
 {
     public class BaseEvenementViewModel : ViewModelDeBase
     {
-
         public Evenement _evenement;
         public TypeEvenement _typeEvenement;
         public INavigation _navigation;
         public IValidator _evenementValidator;
+        public List<Evenement> CalendarInlineEvents { get; set; }
+        public string nomEvenement { get; set; }
+        public string Lieu { get; set; }
+        public List<TypeEvenement> EvenementListPicker { get; set; }
+        public string Nom { get; set; }
+        public DateTime DateDeb { get; set; }
+        public TimeSpan HeureDeb { get; set; }
+        public DateTime? DateFin { get; set; }
+        public DateTime? ProchainEvenemt { get; set; }
+        public string DescriptionEvenement { get; set; }
+        public string SearchText { get; set; }
+        public ObservableRangeCollection<Evenement> EvenementList { get; set; } = new ObservableRangeCollection<Evenement>();
+        public ObservableRangeCollection<Evenement> SearchEvenementList { get; set; } = new ObservableRangeCollection<Evenement>();
 
+        public MvvmHelpers.Commands.Command<string> SearchCommand { get; set; }
 
-
-
-
-
-
-
-        List<Evenement> _calendarInlineEvents;
-        public List<Evenement> CalendarInlineEvents 
+        public BaseEvenementViewModel()
         {
-            get => _calendarInlineEvents;
-            set
+            SearchCommand = new MvvmHelpers.Commands.Command<string>(searchText => DoSearchCommand(searchText));
+
+            EvenementList.CollectionChanged += EvenementList_CollectionChanged;
+        }
+
+        private void EvenementList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            SearchEvenementList.Clear();
+            SearchEvenementList.AddRange(EvenementList);
+        }
+
+        void DoSearchCommand(string searchText)
+        {
+            if (string.IsNullOrEmpty(searchText))
             {
-                _calendarInlineEvents = value;
-                NotifyPropertyChanged("CalendarInlineEvents");
+                SearchEvenementList.Clear();
+                SearchEvenementList.AddRange(EvenementList);
             }
-        }
-
-
-
-        public string nomEvenement
-        {
-            get => _evenement.nomEvenement;
-            set
+            else
             {
-                _evenement.nomEvenement = value;
-                NotifyPropertyChanged("nomEvenement");
+                SearchEvenementList.Clear();
+                SearchEvenementList.AddRange(EvenementList.Where(x => x.nomEvenement.Contains(searchText)));
             }
-        }
-
-
-        public string Lieu
-        {
-            get => _evenement.Lieu;
-            set
-            {
-                _evenement.Lieu = value;
-                NotifyPropertyChanged("Lieu");
-            }
-        }
-
-
-        // champs du type evenement
-
-        public List<TypeEvenement> EvenementListPicker
-        {
-            get;
-            set;
-        }
-
-        public string Nom
-        {
-            get => _typeEvenement.Nom;
-
-            set
-            {
-                _typeEvenement.Nom = value;
-                NotifyPropertyChanged("Nom");
-            }
-        }
-
-        //fin
-
-        public DateTime DateDeb
-        {
-            get => _evenement.DateDeb;
-            set
-            {
-                _evenement.DateDeb = value;
-                NotifyPropertyChanged("DateDeb");
-            }
-        }
-
-        public TimeSpan HeureDeb
-        {
-            get => _evenement.HeureDeb;
-            set
-            {
-                _evenement.HeureDeb = value;
-                NotifyPropertyChanged("HeureDeb");
-            }
-        }
-
-        public DateTime? DateFin
-        {
-            get => _evenement.DateFin;
-            set
-            {
-                _evenement.DateFin = value;
-                NotifyPropertyChanged("DateFin");
-            }
-        }
-
-        public DateTime? ProchainEvenemt
-        {
-            get => _evenement.ProchainEvenemt;
-            set
-            {
-                _evenement.ProchainEvenemt = value;
-                NotifyPropertyChanged("ProchainEvenemt");
-            }
-        }
-
-
-      
-        public string DescriptionEvenement
-        {
-            get => _evenement.DescriptionEvenement;
-            set
-            {
-                _evenement.DescriptionEvenement = value;
-                NotifyPropertyChanged("DescriptionEvenement");
-            }
-        }
-
-      
-
-
-        List<Evenement> _evenementList;
-        public List<Evenement> EvenementList
-        {
-            get
-            {
-                List<Evenement> theCollection = new List<Evenement>();
-
-                if (_evenementList != null)
-                {
-                    List<Evenement> entities = (from e in _evenementList
-                                                where e.nomEvenement.Contains(_searchText)
-                                               select e).ToList<Evenement>();
-                    if (entities != null && entities.Any())
-                    {
-                        theCollection = new List<Evenement>(entities);
-                    }
-                }
-
-                return theCollection;
-            }
-            set
-            {
-                _evenementList = value;
-                NotifyPropertyChanged("EvenementList");
-            }
-        }
-
-
-
-        private string _searchText = string.Empty;
-        public string SearchText
-        {
-            get { return _searchText; }
-            set
-            {
-                if (_searchText != value) { _searchText = value ?? string.Empty; NotifyPropertyChanged("SearchText"); }
-
-                if (SearchCommand.CanExecute(null))
-                {
-                    SearchCommand.Execute(null);
-                }
-            }
-        }
-
-
-
-        private Command _searchCommand;
-        public ICommand SearchCommand
-        {
-            get
-            {
-                _searchCommand = _searchCommand ?? new Command(DoSearchCommand, CanExecuteSearchCommand);
-                return _searchCommand;
-            }
-        }
-        private void DoSearchCommand()
-        {
-            // Refresh the list, which will automatically apply the search text
-            NotifyPropertyChanged("EvenementList");
-        }
-        private bool CanExecuteSearchCommand()
-        {
-            return true;
         }
 
     }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/CalendarEventViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/CalendarEventViewModel.cs
@@ -44,19 +44,11 @@ namespace SaveAll.ViewModel.ViewModelEvenement
             await _navigation.PushAsync(pr);
         }
 
-        Evenement _selectedItem;
-        public Evenement SelectedItem
+        public Evenement SelectedItem { get; set; }
+
+        void OnSelectedItemChanged()
         {
-            get => _selectedItem;
-            set
-            {
-                if (value != null)
-                {
-                    _selectedItem = value;
-                    NotifyPropertyChanged("SelectedItem");
-                    ShowEvenementsDetails(value.id);
-                }
-            }
+            ShowEvenementsDetails(SelectedItem.id);
         }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/ListEvementViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/ListEvementViewModel.cs
@@ -97,6 +97,7 @@ namespace SaveAll.ViewModel.ViewModelEvenement
 
         public Evenement SelectedItem { get; set; }
 
+        // This method gets called because of PropertyChanged.Fody. Follows the convention: void On[MyProperty]Changed()
         void OnSelectedItemChanged()
         {
             ShowEvenementsDetails(SelectedItem.id);

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/ListEvementViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelEvenement/ListEvementViewModel.cs
@@ -43,7 +43,8 @@ namespace SaveAll.ViewModel.ViewModelEvenement
         async Task FetchEvenements()
         {
 
-            EvenementList = await App.MembreActuel.SesEvenementsAsync();            // fonctionnalite pour recuperer tous les enregistrements
+            EvenementList.Clear();
+            EvenementList.AddRange(await App.MembreActuel.SesEvenementsAsync());            // fonctionnalite pour recuperer tous les enregistrements
         }
 
 
@@ -94,19 +95,11 @@ namespace SaveAll.ViewModel.ViewModelEvenement
             await _navigation.PushAsync(pr);
         }
 
-        Evenement _selectedItem;
-        public Evenement SelectedItem
+        public Evenement SelectedItem { get; set; }
+
+        void OnSelectedItemChanged()
         {
-            get => _selectedItem;
-            set
-            {
-                if (value != null)
-                {
-                    _selectedItem = value;
-                    NotifyPropertyChanged("SelectedItem");
-                    ShowEvenementsDetails(value.id) ;
-                }
-            }
+            ShowEvenementsDetails(SelectedItem.id);
         }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/BaseMembreViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/BaseMembreViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
 using FluentValidation;
+using MvvmHelpers;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Model;
 using Xamarin.Forms;
@@ -16,224 +17,58 @@ namespace SaveAll.ViewModel.ViewModelMembre
 
         public INavigation _navigation;
         public IValidator _membreAjouterValidator;
-      
 
-
-        public string Nom
-        {
-            get => _membre.Nom;
-            set
-            {
-                _membre.Nom = value;
-                NotifyPropertyChanged("Nom");
-            }
-        }
-
-
-
-        public string Prenom
-        {
-            get => _membre.Prenom;
-            set
-            {
-                _membre.Prenom = value;
-                NotifyPropertyChanged("Prenom");
-            }
-        }
-
-        public DateTime DateNaiss
-        {
-            get => _membre.DateNaiss;
-            set
-            {
-                _membre.DateNaiss = value;
-                NotifyPropertyChanged("DateNaiss");
-            }
-        }
-
-
-        public string Sexe
-        {
-            get => _membre.Sexe;
-            set
-            {
-                _membre.Sexe = value;
-                NotifyPropertyChanged("Sexe");
-            }
-        }
-
-
-        public string LieuNaiss
-        {
-            get => _membre.LieuNaiss;
-            set
-            {
-                _membre.LieuNaiss = value;
-                NotifyPropertyChanged("LieuNaiss");
-            }
-        }
-
-
-        public string GroupeSanguin
-        {
-            get => _membre.GroupeSanguin;
-            set
-            {
-                _membre.GroupeSanguin = value;
-                NotifyPropertyChanged("GroupeSanguin");
-            }
-        }
-
-        public string Telephone
-        {
-            get => _membre.Telephone;
-            set
-            {
-                _membre.Telephone = value;
-                NotifyPropertyChanged("Telephone");
-            }
-        }
-
-        public string Telephone2
-        {
-            get => _membre.Telephone2;
-            set
-            {
-                _membre.Telephone2 = value;
-                NotifyPropertyChanged("Telephone2");
-            }
-        }
-
-
-        public string Adresse
-        {
-            get => _membre.Adresse;
-            set
-            {
-                _membre.Adresse = value;
-                NotifyPropertyChanged("Adresse");
-            }
-        }
-
-        public string Adresse2
-        {
-            get => _membre.Adresse2;
-            set
-            {
-                _membre.Adresse2 = value;
-                NotifyPropertyChanged("Adresse2");
-            }
-        }
-
-
-
-
-        public bool? Principal
-        {
-            get;
-            set;
-        }
-
-
-
+        public string Nom { get; set; }
+        public string Prenom { get; set; }
+        public DateTime DateNaiss { get; set; }
+        public string Sexe { get; set; }
+        public string LieuNaiss { get; set; }
+        public string GroupeSanguin { get; set; }
+        public string Telephone { get; set; }
+        public string Telephone2 { get; set; }
+        public string Adresse { get; set; }
+        public string Adresse2 { get; set; }
+        public bool? Principal { get; set; }
+        public string SearchText { get; set; }
         /// <summary>
         /// INFOS TYPE MEMBRE
         /// </summary>
         /// 
 
-        public List<TypeMembre> TypeMembreList
+        public List<TypeMembre> TypeMembreList { get; set; }
+        public string NomTypeMembre { get; set; }
+        public string TypeEnr { get; set; }
+
+        public ObservableRangeCollection<Membre> MembreList { get; set; } = new ObservableRangeCollection<Membre>();
+        public ObservableRangeCollection<Membre> SearchMembreList { get; set; } = new ObservableRangeCollection<Membre>();
+
+        public MvvmHelpers.Commands.Command<string> SearchCommand { get; set; }
+
+        public BaseMembreViewModel()
         {
-            get;
-            set;
+            SearchCommand = new MvvmHelpers.Commands.Command<string>(searchText => DoSearchCommand(searchText));
+
+            MembreList.CollectionChanged += MembreList_CollectionChanged;
         }
 
-        public string NomTypeMembre
+        private void MembreList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            get => _typeMembre.NomTypeMembre;
+            SearchMembreList.Clear();
+            SearchMembreList.AddRange(MembreList);
+        }
 
-            set
+        void DoSearchCommand(string searchText)
+        {
+            if (string.IsNullOrEmpty(searchText))
             {
-                _typeMembre.NomTypeMembre = value;
-                NotifyPropertyChanged("NomTypeMembre");
+                SearchMembreList.Clear();
+                SearchMembreList.AddRange(MembreList);
+            }
+            else
+            {
+                SearchMembreList.Clear();
+                SearchMembreList.AddRange(MembreList.Where(x => x.Nom.Contains(searchText)));
             }
         }
-
-
-        public string TypeEnr
-        {
-            get;
-            set;
-        }
-
-
-        List<Membre> _membreList;
-        public List<Membre> MembreList
-        {
-            get
-            {
-                List<Membre> theCollection = new List<Membre>();
-
-                if (_membreList != null)
-                {
-                    List<Membre> entities = (from e in _membreList
-                                             where e.Nom.Contains(_searchText)
-                                               select e).ToList<Membre>();
-                    if (entities != null && entities.Any())
-                    {
-                        theCollection = new List<Membre>(entities);
-                    }
-                    else
-                    {
-
-                    }
-                }
-
-                return theCollection;
-            }
-
-            set
-            {
-                _membreList = value;
-                NotifyPropertyChanged("MembreList");
-            }
-        }
-
-
-        private string _searchText = string.Empty;
-        public string SearchText
-        {
-            get { return _searchText; }
-            set
-            {
-                if (_searchText != value) { _searchText = value ?? string.Empty; NotifyPropertyChanged("SearchText"); }
-
-                if (SearchCommand.CanExecute(null))
-                {
-                    SearchCommand.Execute(null);
-                }
-            }
-        }
-
-
-
-        private Command _searchCommand;
-        public ICommand SearchCommand
-        {
-            get
-            {
-                _searchCommand = _searchCommand ?? new Command(DoSearchCommand, CanExecuteSearchCommand);
-                return _searchCommand;
-            }
-        }
-        private void DoSearchCommand()
-        {
-            // Refresh the list, which will automatically apply the search text
-            NotifyPropertyChanged("MembreList");
-        }
-        private bool CanExecuteSearchCommand()
-        {
-            return true;
-        }
-
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/ListMembreViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/ListMembreViewModel.cs
@@ -41,8 +41,8 @@ namespace SaveAll.ViewModel.ViewModelMembre
         /// <returns></returns>
         async Task FetchMembre()
         {
-
-            MembreList = await App.MembreActuel.EnfantsAsync();            // fonctionnalite pour recuperer tous les enregistrements
+            MembreList.Clear();
+            MembreList.AddRange(await App.MembreActuel.EnfantsAsync());            // fonctionnalite pour recuperer tous les enregistrements
         }
 
 
@@ -87,19 +87,11 @@ namespace SaveAll.ViewModel.ViewModelMembre
             await _navigation.PushAsync(new DetailMembrePageView(selectedMembreID));
         }
 
-        Membre _selectedItem;
-        public Membre SelectedItem
+        public Membre SelectedItem { get; set; }
+
+        void OnSelectedItemChanged()
         {
-            get => _selectedItem;
-            set
-            {
-                if (value != null)
-                {
-                    _selectedItem = value;
-                    NotifyPropertyChanged("SelectedItem");
-                    ShowMembreDetails(value.Id);
-                }
-            }
+            ShowMembreDetails(SelectedItem.Id);
         }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/ListMembreViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelMembre/ListMembreViewModel.cs
@@ -89,6 +89,7 @@ namespace SaveAll.ViewModel.ViewModelMembre
 
         public Membre SelectedItem { get; set; }
 
+        // This method gets called because of PropertyChanged.Fody. Follows the convention: void On[MyProperty]Changed()
         void OnSelectedItemChanged()
         {
             ShowMembreDetails(SelectedItem.Id);

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/BaseParametresViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/BaseParametresViewModel.cs
@@ -9,25 +9,8 @@ namespace SaveAll.ViewModel.ViewModelParametres
 {
     public class BaseParametresViewModel : ViewModelDeBase
     {
-
         public INavigation _navigation;
 
-
-
-        bool _notifications = true;
-        public bool Notifications
-        {
-            get => _notifications;
-            set
-            {
-                _notifications = value;
-                NotifyPropertyChanged("Notifications");
-            }
-        }
-
-
-
-
-       
+        public bool Notifications { get; set; }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/BaseTypeViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/BaseTypeViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using MvvmHelpers;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Model;
 using System;
@@ -21,106 +22,16 @@ namespace SaveAll.ViewModel.ViewModelParametres.ParametresTypesViewModel
         public TypeMembre _typeMembre;
         public TypePatrimoine _typePatrimoine;
 
-
-
-
-
-        public string NomTypeMembre
-        {
-            get => _typeMembre.NomTypeMembre;
-            set
-            {
-                _typeMembre.NomTypeMembre = value;
-                NotifyPropertyChanged("NomTypeMembre");
-            }
-        }
-
-
-        public string Nom
-        {
-            get => _typeEvenment.Nom;
-            set
-            {
-                _typeEvenment.Nom = value;
-                NotifyPropertyChanged("Nom");
-            }
-        }
-
-
-        public string NomTypeDocument
-        {
-            get => _typeDocument.NomTypeDocument;
-            set
-            {
-                _typeDocument.NomTypeDocument = value;
-                NotifyPropertyChanged("NomTypeDocument");
-            }
-        }
-
-
-        public string NomTypePatrimoine
-        {
-            get => _typePatrimoine.NomTypePatrimoine;
-            set
-            {
-                _typePatrimoine.NomTypePatrimoine = value;
-                NotifyPropertyChanged("NomTypePatrimoine");
-            }
-        }
-
-
-
-
-
+        public string NomTypeMembre { get; set; }
+        public string Nom { get; set; }
+        public string NomTypeDocument { get; set; }
+        public string NomTypePatrimoine { get; set; }
 
         // listes des 04 classes types
 
-
-        List<TypeMembre> _typemembreList;
-        public List<TypeMembre> TypeMembreList
-        {
-            get => _typemembreList;
-            set
-            {
-                _typemembreList = value;
-                NotifyPropertyChanged("TypeMembreList");
-            }
-        }
-
-
-
-        List<TypeDocument> _typeDocumentList;
-        public List<TypeDocument> TypeDocumentList
-        {
-            get => _typeDocumentList;
-            set
-            {
-                _typeDocumentList = value;
-                NotifyPropertyChanged("TypeDocumentList");
-            }
-        }
-
-
-        List<TypeEvenement> _typeEvenmentList;
-        public List<TypeEvenement> TypeEvenementList
-        {
-            get => _typeEvenmentList;
-            set
-            {
-                _typeEvenmentList = value;
-                NotifyPropertyChanged("TypeEvenementList");
-            }
-        }
-
-        List<TypePatrimoine> _typePatrimoineList;
-        public List<TypePatrimoine> TypePatrimoineList
-        {
-            get => _typePatrimoineList;
-            set
-            {
-                _typePatrimoineList = value;
-                NotifyPropertyChanged("TypePatrimoineList");
-            }
-        }
+        public ObservableRangeCollection<TypeMembre> TypeMembreList { get; set; } = new ObservableRangeCollection<TypeMembre>();
+        public ObservableRangeCollection<TypeDocument> TypeDocumentList { get; set; } = new ObservableRangeCollection<TypeDocument>();
+        public ObservableRangeCollection<TypeEvenement> TypeEvenementList { get; set; } = new ObservableRangeCollection<TypeEvenement>();
+        public ObservableRangeCollection<TypePatrimoine> TypePatrimoineList { get; set; } = new ObservableRangeCollection<TypePatrimoine>();
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeDocumentViewModel/ListTypeDocumentViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeDocumentViewModel/ListTypeDocumentViewModel.cs
@@ -57,8 +57,8 @@ namespace SaveAll.ViewModel.ViewModelParametres.ParametresTypesViewModel.TypeDoc
 
         async Task FetchtypeDocument()
         {
-
-            TypeDocumentList = await new DatabaseHelper().TousLesTypesDocumentsAsync();            // fonctionnalite pour recuperer tous les enregistrements
+            TypeDocumentList.Clear();
+            TypeDocumentList.AddRange(await new DatabaseHelper().TousLesTypesDocumentsAsync());            // fonctionnalite pour recuperer tous les enregistrements
 
         }
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeEvenementViewModel/ListTypeEvenementViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeEvenementViewModel/ListTypeEvenementViewModel.cs
@@ -57,7 +57,8 @@ namespace SaveAll.ViewModel.ViewModelParametres.ParametresTypesViewModel.TypeDoc
 
         async Task FetchtypeEvenement()
         {
-            TypeEvenementList = await new DatabaseHelper().TousLesTypesEvenementsAsync();            // fonctionnalite pour recuperer tous les enregistrements
+            TypeEvenementList.Clear();
+            TypeEvenementList.AddRange(await new DatabaseHelper().TousLesTypesEvenementsAsync());            // fonctionnalite pour recuperer tous les enregistrements
 
         }
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeMembreViewModel/ListTypeMembreViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypeMembreViewModel/ListTypeMembreViewModel.cs
@@ -56,7 +56,8 @@ namespace SaveAll.ViewModel.ViewModelParametres.ParametresTypesViewModel.TypeDoc
 
         async Task FetchtypeMembre()
         {
-            TypeMembreList = await new DatabaseHelper().TousLesTypesMembres();            // fonctionnalite pour recuperer tous les enregistrements
+            TypeMembreList.Clear();
+            TypeMembreList.AddRange(await new DatabaseHelper().TousLesTypesMembres());            // fonctionnalite pour recuperer tous les enregistrements
 
         }
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypePatrimoineViewModel/ListTypePatrimoineViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelParametres/ParametresTypesViewModel/TypePatrimoineViewModel/ListTypePatrimoineViewModel.cs
@@ -56,7 +56,8 @@ namespace SaveAll.ViewModel.ViewModelParametres.ParametresTypesViewModel.TypeDoc
 
         async Task FetchtypePatrimoine()
         {
-            TypePatrimoineList = await new DatabaseHelper().TousLesTypesPatrimoines();            // fonctionnalite pour recuperer tous les enregistrements
+            TypePatrimoineList.Clear();
+            TypePatrimoineList.AddRange(await new DatabaseHelper().TousLesTypesPatrimoines());            // fonctionnalite pour recuperer tous les enregistrements
 
         }
 

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/BasePatrimoineViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/BasePatrimoineViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using MvvmHelpers;
 using SaveAll.FrameworkMVVM;
 using SaveAll.Helpers;
 using SaveAll.Interfaces;
@@ -23,271 +24,121 @@ namespace SaveAll.ViewModel.ViewModelPatrimoine
         public IMultiMediaPickerService _multiMediaPickerService;
         public ObservableCollection<Patrimoine> Media { get; set; }
 
-
-
-        public BasePatrimoineViewModel()
-        {
-
-         //   PinCollection.Add(new Pin() { Position = MyPosition, Type = PinType.Generic, Label = "" + NomDuBien });
-         //
-         //
-         //   Task.Run(async () =>
-		//	{
-		//		var position = await Plugin.Geolocator.CrossGeolocator.Current.GetPositionAsync();
-         //       MyPosition = new Position(position.Latitude, position.Longitude);
-         //
-         //   });
-            
-
-        }
-
-
-
-      //  private ObservableCollection<Pin> _pinCollection = new ObservableCollection<Pin>();
-      //
-      //  public ObservableCollection<Pin> PinCollection
-      //  {
-      //      get
-      //      {
-      //          return _pinCollection;
-      //
-      //      }
-      //      set
-      //      {
-      //          _pinCollection = value;
-      //          NotifyPropertyChanged("PinCollection");
-      //      }
-      //  }
-
-
-
-      //  public Position MyPosition
-      //  { 
-      //      get => _patrimoine.MyPosition.ToPosition();
-      //      set
-      //      {
-      //          _patrimoine.MyPosition = value.ToStringPosition();
-      //          NotifyPropertyChanged("MyPosition");
-      //      }
-      //  }
-      //
-     
-
-
-        public string NomDuBien
-        {
-            get => _patrimoine.NomDuBien;
-
-            set
-            {
-                _patrimoine.NomDuBien = value;
-                NotifyPropertyChanged("NomDuBien");
-            }
-        }
-
-        public string NumeroDuBien
-        {
-            get => _patrimoine.NumeroDuBien;
-
-            set
-            {
-                _patrimoine.NumeroDuBien = value;
-                NotifyPropertyChanged("NumeroDuBien");
-            }
-        }
-
-        public string DescriptionPatrimoine
-        {
-            get => _patrimoine.DescriptionPatrimoine;
-
-            set
-            {
-                _patrimoine.DescriptionPatrimoine = value;
-                NotifyPropertyChanged("DescriptionPatrimoine");
-            }
-        }
-
+        public string NomDuBien { get; set; }
+        public string NumeroDuBien { get; set; }
+        public string DescriptionPatrimoine { get; set; }
 
         /// <summary>
         /// INFOS TYPE PATRIMOINE
         /// </summary>
 
-        public List<TypePatrimoine> TypePatrimoineList
+        public List<TypePatrimoine> TypePatrimoineList { get; set; }
+
+        public string NomTypePatrimoine { get; set; }
+        public DateTime? DateAcquisition { get; set; }
+        public string ValeurAcquisition { get; set; }
+        public string ValeurActuel { get; set; }
+        public string Path { get; set; }
+        public string PreviewPath { get; set; }
+        public string SearchText { get; set; }
+
+        public ObservableRangeCollection<Patrimoine> PatrimoineList { get; set; } = new ObservableRangeCollection<Patrimoine>();
+        public ObservableRangeCollection<Patrimoine> SearchPatrimoineList { get; set; } = new ObservableRangeCollection<Patrimoine>();
+
+        public MvvmHelpers.Commands.Command<string> SearchCommand { get; set; }
+
+        public BasePatrimoineViewModel()
         {
-            get;
-            set;
+            //   PinCollection.Add(new Pin() { Position = MyPosition, Type = PinType.Generic, Label = "" + NomDuBien });
+            //
+            //
+            //   Task.Run(async () =>
+            //	{
+            //		var position = await Plugin.Geolocator.CrossGeolocator.Current.GetPositionAsync();
+            //       MyPosition = new Position(position.Latitude, position.Longitude);
+            //
+            //   });
+
+            SearchCommand = new MvvmHelpers.Commands.Command<string>(searchText => DoSearchCommand(searchText));
+
+            PatrimoineList.CollectionChanged += PatrimoineList_CollectionChanged;
         }
 
-        public string NomTypePatrimoine
+        private void PatrimoineList_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            get => _typePatrimoine.NomTypePatrimoine;
+            SearchPatrimoineList.Clear();
+            SearchPatrimoineList.AddRange(PatrimoineList);
+        }
 
-            set
+        void DoSearchCommand(string searchText)
+        {
+            if (string.IsNullOrEmpty(searchText))
             {
-                _typePatrimoine.NomTypePatrimoine = value;
-                NotifyPropertyChanged("NomTypePatrimoine");
+                SearchPatrimoineList.Clear();
+                SearchPatrimoineList.AddRange(PatrimoineList);
+            }
+            else
+            {
+                SearchPatrimoineList.Clear();
+                SearchPatrimoineList.AddRange(PatrimoineList.Where(x => x.NomDuBien.Contains(searchText)));
             }
         }
 
-        public DateTime? DateAcquisition
-        {
-            get => _patrimoine.DateAcquisition;
-
-            set
-            {
-                _patrimoine.DateAcquisition = value;
-                NotifyPropertyChanged("DateAcquisition");
-            }
-
-        }
-
-        public string ValeurAcquisition
-        {
-            get => _patrimoine.ValeurAcquisition;
-
-            set
-            {
-                _patrimoine.ValeurAcquisition = value;
-                NotifyPropertyChanged("ValeurAcquisition");
-            }
-
-        }
+        //  private ObservableCollection<Pin> _pinCollection = new ObservableCollection<Pin>();
+        //
+        //  public ObservableCollection<Pin> PinCollection
+        //  {
+        //      get
+        //      {
+        //          return _pinCollection;
+        //
+        //      }
+        //      set
+        //      {
+        //          _pinCollection = value;
+        //          NotifyPropertyChanged("PinCollection");
+        //      }
+        //  }
 
 
-        public string ValeurActuel
-        {
-            get => _patrimoine.ValeurActuel;
 
-            set
-            {
-                _patrimoine.ValeurActuel = value;
-                NotifyPropertyChanged("ValeurActuel");
-            }
-
-        }
-
-   
-
-        public string Path
-        {
-            get => _patrimoine.Path;
-            set
-            {
-                _patrimoine.Path = value;
-                NotifyPropertyChanged("Path");
-            }
-        }
-
-        public string PreviewPath
-        {
-            get => _patrimoine.PreviewPath;
-            set
-            {
-                _patrimoine.PreviewPath = value;
-                NotifyPropertyChanged("PreviewPath");
-            }
-        }
-
-       
-
-      //  public double Longitude
-      //  {
-      //      get => _patrimoine.Longitude;
-      //      set
-      //      {
-      //          _patrimoine.Longitude = value;
-      //          NotifyPropertyChanged("Longitude");
-      //      }
-      //  }
-      //
-      //
-      //
-      //  public double Latitude
-      //  {
-      //      get => _patrimoine.Latitude;
-      //      set
-      //      {
-      //          _patrimoine.Latitude = value;
-      //          NotifyPropertyChanged("Latitude");
-      //      }
-      //  }
-      //
+        //  public Position MyPosition
+        //  { 
+        //      get => _patrimoine.MyPosition.ToPosition();
+        //      set
+        //      {
+        //          _patrimoine.MyPosition = value.ToStringPosition();
+        //          NotifyPropertyChanged("MyPosition");
+        //      }
+        //  }
+        //
 
 
 
 
-        List<Patrimoine> _patrimoineList;
-        public List<Patrimoine> PatrimoineList
-        {
-            get
-            {
-                List<Patrimoine> theCollection = new List<Patrimoine>();
 
-                if (_patrimoineList != null)
-                {
-                    List<Patrimoine> entities = (from e in _patrimoineList
-                                               where e.NomDuBien.Contains(_searchText)
-                                               select e).ToList<Patrimoine>();
-                    if (entities != null && entities.Any())
-                    {
-                        theCollection = new List<Patrimoine>(entities);
-                    }
-                    else
-                    {
-
-                    }
-                }
-
-                return theCollection;
-            }
-            set
-            {
-                _patrimoineList = value;
-                NotifyPropertyChanged("PatrimoineList");
-            }
-        }
-
-
-
-        private string _searchText = string.Empty;
-        public string SearchText
-        {
-            get { return _searchText; }
-            set
-            {
-                if (_searchText != value) { _searchText = value ?? string.Empty; NotifyPropertyChanged("SearchText"); }
-
-                if (SearchCommand.CanExecute(null))
-                {
-                    SearchCommand.Execute(null);
-                }
-            }
-        }
-
-
-
-        private Command _searchCommand;
-        public ICommand SearchCommand
-        {
-            get
-            {
-                _searchCommand = _searchCommand ?? new Command(DoSearchCommand, CanExecuteSearchCommand);
-                return _searchCommand;
-            }
-        }
-        private void DoSearchCommand()
-        {
-            // Refresh the list, which will automatically apply the search text
-            NotifyPropertyChanged("PatrimoineList");
-        }
-        private bool CanExecuteSearchCommand()
-        {
-            return true;
-        }
-
-
-
-
+        //  public double Longitude
+        //  {
+        //      get => _patrimoine.Longitude;
+        //      set
+        //      {
+        //          _patrimoine.Longitude = value;
+        //          NotifyPropertyChanged("Longitude");
+        //      }
+        //  }
+        //
+        //
+        //
+        //  public double Latitude
+        //  {
+        //      get => _patrimoine.Latitude;
+        //      set
+        //      {
+        //          _patrimoine.Latitude = value;
+        //          NotifyPropertyChanged("Latitude");
+        //      }
+        //  }
+        //
 
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/ListPatrimoineViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/ListPatrimoineViewModel.cs
@@ -97,6 +97,7 @@ namespace SaveAll.ViewModel.ViewModelPatrimoine
 
         public Patrimoine SelectedItem { get; set; }
 
+        // This method gets called because of PropertyChanged.Fody. Follows the convention: void On[MyProperty]Changed()
         void OnSelectedItemChanged()
         {
             ShowPatrimoineDetails(SelectedItem.Id);

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/ListPatrimoineViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelPatrimoine/ListPatrimoineViewModel.cs
@@ -16,7 +16,6 @@ namespace SaveAll.ViewModel.ViewModelPatrimoine
 
         public ICommand DeleteAllCommand { get; private set; }
         public ICommand AjouterCommand { get; private set; }
-        public ICommand SearchCommand { get; private set; }
 
 
         public ListPatrimoineViewModel(INavigation navigation)
@@ -47,10 +46,8 @@ namespace SaveAll.ViewModel.ViewModelPatrimoine
 
         async Task FetchPatrimoine()
         {
-
-            PatrimoineList = await App.MembreActuel.SesBiens();            // fonctionnalite pour recuperer tous les enregistrements
-
-
+            PatrimoineList.Clear();
+            PatrimoineList.AddRange(await App.MembreActuel.SesBiens());            // fonctionnalite pour recuperer tous les enregistrements
         }
 
 
@@ -98,19 +95,11 @@ namespace SaveAll.ViewModel.ViewModelPatrimoine
             await _navigation.PushAsync(pr);
         }
 
-        Patrimoine _selectedItem;
-        public Patrimoine SelectedItem
+        public Patrimoine SelectedItem { get; set; }
+
+        void OnSelectedItemChanged()
         {
-            get => _selectedItem;
-            set
-            {
-                if (value != null)
-                {
-                    _selectedItem = value;
-                    NotifyPropertyChanged("SelectedItem");
-                    ShowPatrimoineDetails(value.Id);
-                }
-            }
+            ShowPatrimoineDetails(SelectedItem.Id);
         }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelUtilisateur/BaseUtilisateurViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelUtilisateur/BaseUtilisateurViewModel.cs
@@ -1,13 +1,8 @@
-﻿using FluentValidation;
-using SaveAll.Controls;
+﻿using System;
+using FluentValidation;
 using SaveAll.FrameworkMVVM;
-using SaveAll.Helpers;
 using SaveAll.Interfaces;
 using SaveAll.Model;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using Xamarin.Forms;
 
 namespace SaveAll.ViewModel.ViewModelUtilisateur
@@ -30,241 +25,28 @@ namespace SaveAll.ViewModel.ViewModelUtilisateur
         public IValidator _utilisateurModelValidator;
         public IValidator _utilisateurLoginValidator;
 
-
-
-
-        public string Login
-        {
-            get => _membre.Login;
-            set
-            {
-                _membre.Login = value;
-                NotifyPropertyChanged("Login");
-            }
-        }
-
-        public string Pass
-        {
-            get => _membre.Pass;
-            set
-            {
-                _membre.Pass = value;
-                NotifyPropertyChanged("Pass");
-                
-            }
-        }
-
-
-
-        public string ConfirmPass
-        {
-            get => _confirmPass;
-            set
-            {
-                _confirmPass = value;
-                NotifyPropertyChanged("ConfirmPass");
-            }
-        }
-
-
-        public string PassActuel
-        {
-            get => _membreModifPassword.PassActuel;
-            set
-            {
-                _membreModifPassword.PassActuel = value;
-                NotifyPropertyChanged("PassActuel");
-            }
-        }
-
-
-
-
-        public string Nom
-        {
-            get => _membre.Nom;
-            set
-            {
-                _membre.Nom = value;
-                NotifyPropertyChanged("Nom");
-            }
-        }
-
-
-        
-        public string Prenom
-        {
-            get => _membre.Prenom;
-            set
-            {
-                _membre.Prenom = value;
-                NotifyPropertyChanged("Prenom");
-            }
-        }
-
-        public DateTime DateNaiss
-        {
-            get => _membre.DateNaiss;
-            set
-            {
-                _membre.DateNaiss = value;
-                NotifyPropertyChanged("DateNaiss");
-            }
-        }
-
-        
-        public string Sexe
-        {
-            get => _membre.Sexe;
-            set
-            {
-                _membre.Sexe = value;
-                NotifyPropertyChanged("Sexe");
-            }
-        }
-
-       
-        public string LieuNaiss
-        {
-            get => _membre.LieuNaiss ;
-            set
-            {
-                _membre.LieuNaiss = value;
-                NotifyPropertyChanged("LieuNaiss");
-            }
-        }
-
-  
-        public string GroupeSanguin
-        {
-            get => _membre.GroupeSanguin;
-            set
-            {
-                _membre.GroupeSanguin = value;
-                NotifyPropertyChanged("GroupeSanguin");
-            }
-        }
-
-        public string Telephone
-        {
-            get => _membre.Telephone;
-            set
-            {
-                _membre.Telephone = value;
-                NotifyPropertyChanged("Telephone");
-            }
-        }
-
-        public string Telephone2
-        {
-            get => _membre.Telephone2;
-            set
-            {
-                _membre.Telephone2 = value;
-                NotifyPropertyChanged("Telephone2");
-            }
-        }
-
-
-        public string Adresse
-        {
-            get => _membre.Adresse;
-            set
-            {
-                _membre.Adresse = value;
-                NotifyPropertyChanged("Adresse");
-            }
-        }
-
-
-        public string Adresse2
-        {
-            get => _membre.Adresse2;
-            set
-            {
-                _membre.Adresse2 = value;
-                NotifyPropertyChanged("Adresse2");
-            }
-        }
-
-
-        public string Nationalite
-        {
-            get => _membre.Nationalite;
-            set
-            {
-                _membre.Nationalite = value;
-                NotifyPropertyChanged("Nationalite");
-            }
-        }
-
-
-        public string QuestionPiege
-        {
-            get => _membre.QuestionPiege;
-            set
-            {
-                _membre.QuestionPiege = value;
-                NotifyPropertyChanged("QuestionPiege");
-            }
-        }
-
-       
-        public string Reponse
-        {
-            get => _membre.Reponse;
-            set
-            {
-                _membre.Reponse = value;
-                NotifyPropertyChanged("Reponse");
-            }
-        }
-
-        public bool? Principal
-        {
-            get;
-            set;
-        }
-
-   
-        public DateTime? DateEnr
-        {
-            get;
-            set;
-        } = DateTime.Now;
-
-        public DateTime? DateDerModif
-        {
-            get;
-            set;
-        } = DateTime.Now;
-
-        public string TypeEnr
-        {
-            get;
-            set;
-        }
-
-
-        public bool IsEditing
-        {
-            get;
-            set;
-        }
-
-
-        public byte[] Photo
-        {
-            get => _membre.Photo;
-            set
-            {
-               
-                _membre.Photo = value;
-                NotifyPropertyChanged("Photo");
-
-                
-            }
-
-        }
+        public string Login { get; set; }
+        public string Pass { get; set; }
+        public string ConfirmPass { get; set; }
+        public string PassActuel { get; set; }
+        public string Nom { get; set; }
+        public string Prenom { get; set; }
+        public DateTime DateNaiss { get; set; }
+        public string Sexe { get; set; }
+        public string LieuNaiss { get; set; }
+        public string GroupeSanguin { get; set; }
+        public string Telephone { get; set; }
+        public string Telephone2 { get; set; }
+        public string Adresse { get; set; }
+        public string Adresse2 { get; set; }
+        public string Nationalite { get; set; }
+        public string QuestionPiege { get; set; }
+        public string Reponse { get; set; }
+        public bool? Principal { get; set; }
+        public DateTime? DateEnr { get; set; } = DateTime.Now;
+        public DateTime? DateDerModif { get; set; } = DateTime.Now;
+        public string TypeEnr { get; set; }
+        public bool IsEditing { get; set; }
+        public byte[] Photo { get; set; }
     }
 }

--- a/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelUtilisateur/LoginUtilisateurViewModel.cs
+++ b/SaveAll/SaveAll/SaveAll/ViewModel/ViewModelUtilisateur/LoginUtilisateurViewModel.cs
@@ -17,16 +17,7 @@ namespace SaveAll.ViewModel.ViewModelUtilisateur
         public ICommand ForgetPasswordPageCommand { get; private set; }
         public ICommand ExitCommand { get; private set; }
 
-        private bool _state;
-        public bool State
-        {
-            get => _state;
-            set
-            {
-                _state = value;
-                NotifyPropertyChanged("State");
-            }
-        }
+        public bool State { get; set; }
 
 
         public LoginUtilisateurViewModel(INavigation navigation )
@@ -94,6 +85,12 @@ namespace SaveAll.ViewModel.ViewModelUtilisateur
 
         async Task LoginUtilisateur()
         {
+            if (string.IsNullOrWhiteSpace(_membre.Login)) // I had to do this because _membre.Login always seemed to be null.
+                _membre.Login = Login;
+
+            if (string.IsNullOrWhiteSpace(_membre.Pass)) // I had to do this because _membre.Pass always seemed to be null.
+                _membre.Pass = Pass;
+
             var validationDesInfos = _utilisateurLoginValidator.Validate(this);
 
             if (validationDesInfos.IsValid)


### PR DESCRIPTION
- Completely refactored viewmodels to take advantage of PropertyChanged.Fody
    - Added the `[AddINotifyPropertyChangedInterface]` attribute to the base viewmodel (which cascades to all the inheriting viewmodels)
- Improved search logic
- Made `TypeDocument` a public property (it was previously private, so it could not be bound to).
- Introduced Refractored.MvvmHelpers (very useful nuget)
    - Use `ObservableRangeCollection<T>` instead of `List<T>`
    - Various improved ICommand implementations, such as `Command<T>` and `AsyncCommand`
- Demonstrated `On[MyProperty]Changed` convention and `[DependsOn(...)] `attribute (both from PropertyChanged.Fody) in the `BaseDocumentViewModel` class